### PR TITLE
[develop-codebuild] CodeBuild版の検証

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,11 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - build
+      - build:
+          filters:
+            only:
+              - master
+              - develop
       - deploy:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ workflows:
       - build:
           filters:
             only:
-              - master
+              #- master
               - develop
       - deploy:
           requires:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,3 +1,24 @@
 version: 0.2
 
 # https://docs.aws.amazon.com/ja_jp/codebuild/latest/userguide/build-spec-ref.html
+#
+# デプロイ先のS3バケット名はParameter Storeを利用する
+#
+
+env:
+  variables:
+    DOCS_ROOT: /tmp/website
+  parameter-store:
+    DEPLOY_S3_BUCKET_NAME: CI_DOCS_CODEBUILD_DEPLOY_BUCKET
+
+phases:
+  install:
+    commands:
+      - pip install awscli
+  build:
+    commands:
+      - mkdocs build
+  post_build:
+    commands:
+      - mv site/ ${DOCS_ROOT}/
+      - aws s3 sync --exact-timestamp --delete ${DOCS_ROOT}/site/ s3://${DEPLOY_S3_BUCKET_NAME}/

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,3 @@
+version: 0.2
+
+# https://docs.aws.amazon.com/ja_jp/codebuild/latest/userguide/build-spec-ref.html


### PR DESCRIPTION
CodeBuild用のbuildspec.ymlを追加

CodeBuildでは特定ブランチに対する指定が出来ない模様
そのため、CircleCI側のconfigでbuildジョブがmasterブランチへのpushで動かないように設定を変更した